### PR TITLE
termux-url-opener: Extracts URL from input.

### DIFF
--- a/termux-url-opener
+++ b/termux-url-opener
@@ -1,7 +1,8 @@
 #!/data/data/com.termux/files/usr/bin/bash
 
 # Get the URL
-URL=$1
+INPUT=$1
+URL=$(echo $1 | grep -Eo 'http[s]*://[^ >]+' | head -1)
 echo "Opening URL"
 
 # Cheks if its Youtube or Spotify URL and downloads it


### PR DESCRIPTION
Solves the "Here's a song for you.." problem stated in the README.