### PR TITLE
Revert "termux-url-opener: Extracts URL from input."

### DIFF
--- a/termux-url-opener
+++ b/termux-url-opener
@@ -1,8 +1,7 @@
 #!/data/data/com.termux/files/usr/bin/bash
 
 # Get the URL
-INPUT=$1
-URL=$(echo $1 | grep -Eo 'http[s]*://[^ >]+' | head -1)
+URL=$1
 echo "Opening URL"
 
 # Cheks if its Youtube or Spotify URL and downloads it


### PR DESCRIPTION
Reverts gabosxpiens/youtify#1 
Don't resolve the problem.